### PR TITLE
fix(bower): assign GIF on self

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -9,7 +9,7 @@ module.exports = function (grunt) {
 
   grunt.config('browserify', {
     dist: {
-      src: ['./index.js'],
+      src: ['./browser.js'],
       dest: 'dist/GIF.js'
     }
   });

--- a/browser.js
+++ b/browser.js
@@ -1,0 +1,3 @@
+'use strict';
+
+self.GIF = require('./');

--- a/src/GIFEncoder.js
+++ b/src/GIFEncoder.js
@@ -10,7 +10,7 @@
 var LZWEncoder = require('./LZWEncoder'),
   NeuQuant = require('./NeuQuant');
 
-GIFEncoder = function() {
+var GIFEncoder = function() {
 
   for (var i = 0, chr = {}; i < 256; i++)
     chr[i] = String.fromCharCode(i);

--- a/src/LZWEncoder.js
+++ b/src/LZWEncoder.js
@@ -7,7 +7,7 @@
  * @version 0.1 AS3 implementation
  */
 
-LZWEncoder = function() {
+var LZWEncoder = function() {
 
   var exports = {};
   var EOF = -1;

--- a/src/NeuQuant.js
+++ b/src/NeuQuant.js
@@ -27,7 +27,7 @@
  * @version 0.1 AS3 implementation
  */
 
-NeuQuant = function() {
+var NeuQuant = function() {
 
   var exports = {};
   var netsize = 256; /* number of colours used */


### PR DESCRIPTION
The browserify change broke the Bower build by not assigning the result
to `window` or `self`. This change assigns GIF on `self` so it can be
used from Bower in either the main thread or a Web Worker context.
